### PR TITLE
removed experimental/unsupported setting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,3 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
-
-android.disableResourceValidation=true


### PR DESCRIPTION
>The option setting 'android.disableResourceValidation=true' is experimental and unsupported.
